### PR TITLE
[#20] feat: 가게 상세 조회 API 구현

### DIFF
--- a/src/app/api/stores/[storeId]/route.ts
+++ b/src/app/api/stores/[storeId]/route.ts
@@ -1,3 +1,41 @@
-export async function GET() {
-  // 가게 정보 조회 처리 로직
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const pathnameParts = url.pathname.split("/");
+    const storeId = parseInt(pathnameParts[pathnameParts.length - 1], 10);
+
+    if (isNaN(storeId)) {
+      return NextResponse.json({ message: "유효하지 않은 가게 ID입니다." }, { status: 400 });
+    }
+
+    const store = await prisma.store.findUnique({
+      where: { id: storeId },
+      select: {
+        name: true,
+        openDays: true,
+        address: true,
+        intro: true,
+        content: true,
+        imageUrl: true,
+      },
+    });
+
+    if (!store) {
+      return NextResponse.json({ message: "해당 가게를 찾을 수 없습니다." }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      name: store.name,
+      openDays: store.openDays,
+      address: store.address,
+      intro: store.intro,
+      content: store.content,
+      imageUrl: store.imageUrl,
+    });
+  } catch {
+    return NextResponse.json({ message: "가게 정보를 불러오는 중 오류가 발생했습니다." }, { status: 500 });
+  }
 }

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -5,3 +5,12 @@ export type StoreCardProps = {
   city_province?: string;
   district?: string;
 };
+
+export type StoreDetail = {
+  name: string;
+  openDays: number;
+  address: string;
+  intro: string;
+  content: string;
+  imageUrl: string;
+};


### PR DESCRIPTION
## ✅ PR 내용 요약
- 가게 상세 페이지에서 사용할 데이터를 호출하기 위한 API를 구현했습니다.

## 🔧 작업 내역
- [X] 가게 상세 페이지에서 호출할 가게 정보 호출 API 구현

## 📎 관련 이슈
- 관련 이슈 번호: #20 
resolves #20 