### PR TITLE
[#19] feat: 가게 상세조회 페이지 구현

### DIFF
--- a/src/app/(user)/store/[storeId]/page.tsx
+++ b/src/app/(user)/store/[storeId]/page.tsx
@@ -1,3 +1,45 @@
-export default function UserStoreListPage() {
-  return <h1>사용자가 보는 가게 목록 페이지입니다.</h1>;
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import { Header } from "@/components/layout/Header";
+import StoreImage from "@/components/store/StoreImage";
+import StoreInfo from "@/components/store/StoreInfo";
+import StoreDescription from "@/components/store/StoreDescription";
+import StoreActionButtons from "@/components/store/StoreActionBtns";
+
+type Props = {
+  params: { storeId: string };
+};
+
+export default async function StoreDetailPage({ params }: Props) {
+  const storeId = Number(params.storeId);
+  if (isNaN(storeId)) notFound();
+
+  const store = await prisma.store.findUnique({
+    where: { id: storeId },
+    select: {
+      name: true,
+      openDays: true,
+      address: true,
+      content: true,
+      imageUrl: true,
+    },
+  });
+
+  if (!store) notFound();
+
+  return (
+    <div className="mx-auto w-[90%]">
+      <Header />
+      <div className="mt-10.5 flex max-w-[1920px] flex-col gap-10.5 md:flex-row">
+        <StoreImage imageUrl={store.imageUrl} />
+        <div className="flex flex-1 flex-col justify-between">
+          <div className="flex flex-col gap-5">
+            <StoreInfo name={store.name} openDays={store.openDays} address={store.address} />
+          </div>
+          <StoreDescription content={store.content} />
+          <StoreActionButtons storeId={storeId} />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,9 +10,11 @@
 
   /* Font sizes*/
   .f48 { font-size: 3rem; line-height: 1.4; }       /* 48px */
+  .f40 { font-size: 2.5rem; line-height: 1.4; }     /* 40px */
   .f36 { font-size: 2.25rem; line-height: 1.4; }     /* 36px */
   .f28 { font-size: 1.75rem; line-height: 1.4; }     /* 28px */
   .f24 { font-size: 1.5rem; line-height: 1.5; }      /* 24px */
+  .f22 { font-size: 1.375rem; line-height: 1.5; }    /* 22px */
   .f20 { font-size: 1.25rem; line-height: 1.5; }     /* 20px */
   .f18 { font-size: 1.125rem; line-height: 1.5; }    /* 18px */
   .f16 { font-size: 1rem; line-height: 1.5; }        /* 16px */

--- a/src/components/store/StoreActionBtns.tsx
+++ b/src/components/store/StoreActionBtns.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+export default function StoreActionButtons({ storeId }: { storeId: number }) {
+  const router = useRouter();
+
+  return (
+    <div className="mt-4 flex justify-start gap-3">
+      <Button variant="outline" className="f16 bg-primary-100 text-sub-text hover:bg-primary-200 h-12 w-50 rounded-md border-none" onClick={() => router.push(`/store/${storeId}/order`)}>
+        상품 보기 &gt;
+      </Button>
+
+      <Button variant="outline" className="f16 bg-secondary-100 text-sub-text hover:bg-secondary-300 h-12 w-50 rounded-md border-none" onClick={() => router.push(`/chat`)}>
+        커스텀 주문 &gt;
+      </Button>
+    </div>
+  );
+}

--- a/src/components/store/StoreDescription.tsx
+++ b/src/components/store/StoreDescription.tsx
@@ -1,0 +1,7 @@
+export default function StoreDescription({ content }: { content: string }) {
+  return (
+    <div className="mt-4 max-h-[500px] flex-grow overflow-y-auto pr-1">
+      <p className="f22 text-regular text-sub-text whitespace-pre-line">{content}</p>
+    </div>
+  );
+}

--- a/src/components/store/StoreImage.tsx
+++ b/src/components/store/StoreImage.tsx
@@ -1,0 +1,7 @@
+export default function StoreImage({ imageUrl }: { imageUrl: string }) {
+  return (
+    <div className="bg-line ml-10.5 aspect-square w-full overflow-hidden rounded-md md:w-[600px]">
+      <img src={imageUrl} alt="가게 이미지" className="h-full w-full object-cover" />
+    </div>
+  );
+}

--- a/src/components/store/StoreInfo.tsx
+++ b/src/components/store/StoreInfo.tsx
@@ -1,0 +1,23 @@
+import { getOpenDayMap } from "@/utils/open-days";
+
+export default function StoreInfo({ name, openDays, address }: { name: string; openDays: number; address: string }) {
+  return (
+    <>
+      <h1 className="f36 text-medium text-primary-text leading-none">{name}</h1>
+
+      <div className="f22 text-medium flex items-center leading-none">
+        <img src="/images/calendar.png" alt="달력" className="mr-5 h-5 w-5" />
+        {Object.entries(getOpenDayMap(openDays)).map(([day, isOpen]) => (
+          <span key={day} className={isOpen ? "text-primary-300" : "text-line"}>
+            {day}
+          </span>
+        ))}
+      </div>
+
+      <div className="flex items-center">
+        <img src="/images/location.png" alt="위치" className="mr-5 h-5 w-5" />
+        <p className="f22 text-medium text-sub-text leading-none">{address}</p>
+      </div>
+    </>
+  );
+}

--- a/src/lib/api/store.ts
+++ b/src/lib/api/store.ts
@@ -1,0 +1,10 @@
+import { StoreDetail } from "@/types/store";
+
+export async function getStoreDetail(storeId: string): Promise<StoreDetail | null> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/stores/${storeId}`, {
+    next: { revalidate: 60 },
+  });
+
+  if (!res.ok) return null;
+  return res.json();
+}

--- a/src/utils/open-days.ts
+++ b/src/utils/open-days.ts
@@ -1,0 +1,11 @@
+export const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+
+export function getOpenDayMap(bitmask: number): Record<string, boolean> {
+  return WEEKDAYS.reduce(
+    (result, day, index) => {
+      result[day] = Boolean(bitmask & (1 << index));
+      return result;
+    },
+    {} as Record<string, boolean>
+  );
+}


### PR DESCRIPTION
## ✅ PR 내용 요약
- 가게 목록에서 가게 카드를 클릭했을 때 진입하는 가게 상세조회 페이지의 UI를 구현했습니다.
(user)>store>[storeid]>page.tsx 경로.

## 🔧 작업 내역
- [X] 대표 이미지 추가 (StoreImage 컴포넌트)
- [X] 가게 이름, 영업 요일, 주소 정보 표시 (StoreInfo.tsx 컴포넌트)
- [X] 영업 요일 선택된 항목 강조 스타일 적용
- [X] 소개글 출력 및 스타일 적용 (StoreDescription.tsx 컴포넌트)
- [X] "상품 보기", "커스텀 주문" 버튼 UI 구현 (StoreActionBtns.tsx 컴포넌트)
- [X] openDays 값을 요일별 활성 여부로 변환하는 getOpenDayMap 유틸 함수 구현
- [X] fetch 함수 (getStoreDetail) 추가 및 lib/api/store.ts에 위치

## 📎 관련 이슈
- 관련 이슈 번호: #19
resolves #19 

## 📸 스크린샷 (UI 변경 시 필수)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/08bf1e18-d340-4749-87d6-adc95bc95761" />


## 💬 기타 사항
- 제작한 컴포넌트는 상품 페이지에서 재활용할 수 있을 듯 합니다:)
