### PR TITLE
[#25] feat: 상품 상세 조회 API 구현

### DIFF
--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -30,3 +30,9 @@ export type OptionItem = {
   addtionalPrice?: number;
   description?: string;
 };
+
+export type ProductPreview = {
+  id: number;
+  name: string;
+  imageUrl: string | null;
+};


### PR DESCRIPTION
## ✅ PR 내용 요약
- 각 가게(store) 별 상품(product)의 목록을 불러오는 API를 구현했습니다.

## 🔧 작업 내역
- [X] GET /api/stores/[storeId]/products API 핸들러 생성
- [X] storeId를 기반으로 해당 가게의 상품 목록 조회
- [X] 응답 필드: id, name, imageUrl
- [X] 에러메세지 처리

## 📎 관련 이슈
- 관련 이슈 번호: #25 
resolves #25 