### PR TITLE
[#28] refactor: 가게 목록 컴포넌트에서 fetch 함수 추출

### DIFF
--- a/src/components/store/StoreList.tsx
+++ b/src/components/store/StoreList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import RegionSelectBox from "./RegionSelectBox";
 import { StoreCard } from "./StoreCard";
 import type { StoreCardProps } from "@/types/store";
+import { getFilteredStores } from "@/lib/api/store";
 
 type Props = {
   initialStores: StoreCardProps[];
@@ -16,13 +17,12 @@ export default function StoreList({ initialStores }: Props) {
 
   useEffect(() => {
     const fetchStores = async () => {
-      const params = new URLSearchParams();
-      if (selectedProvince) params.append("city_province", selectedProvince);
-      if (selectedDistrict) params.append("district", selectedDistrict);
-
-      const res = await fetch(`/api/stores?${params.toString()}`);
-      const data = await res.json();
-      setStores(data);
+      try {
+        const data = await getFilteredStores(selectedProvince, selectedDistrict);
+        setStores(data);
+      } catch {
+        console.error("가게 불러오기 실패");
+      }
     };
 
     fetchStores();

--- a/src/lib/api/store.ts
+++ b/src/lib/api/store.ts
@@ -1,4 +1,5 @@
 import { StoreDetail } from "@/types/store";
+import { StoreCardProps } from "@/types/store";
 
 export async function getStoreDetail(storeId: string): Promise<StoreDetail | null> {
   const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/stores/${storeId}`, {
@@ -6,5 +7,19 @@ export async function getStoreDetail(storeId: string): Promise<StoreDetail | nul
   });
 
   if (!res.ok) return null;
+  return res.json();
+}
+
+export async function getFilteredStores(province: string | null, district: string | null): Promise<StoreCardProps[]> {
+  const params = new URLSearchParams();
+  if (province) params.append("city_province", province);
+  if (district) params.append("district", district);
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/stores?${params.toString()}`, {
+    next: { revalidate: 60 },
+  });
+
+  if (!res.ok) return [];
+
   return res.json();
 }


### PR DESCRIPTION
## ✅ PR 내용 요약
- StoreList의 데이터 fetch 로직 분리 및 API 유틸화 진행했습니다.


## 🔧 작업 내역
- [X] lib/api/store.ts 에 getFilteredStores(province, district) 함수 구현
- [X] fetch('/api/stores?...') 호출
- [X] 기존 StoreList.tsx 내 useEffect 로직을 getFilteredStores 호출로 대체
- [X] 변경 후 정상적으로 가게 목록이 불러와 지고 필터링 되는지 확인

## 📎 관련 이슈
- 관련 이슈 번호: #28 
- resolves #28 