### PR TITLE
[#23] feat: 상품 상세 조회 화면 구현

### DIFF
--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -1,0 +1,10 @@
+import { Header } from "@/components/layout/Header";
+
+export default function UserLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto flex w-[90%] flex-col items-center">
+      <Header />
+      {children}
+    </div>
+  );
+}

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -1,4 +1,3 @@
-import { Header } from "@/components/layout/Header";
 import { prisma } from "@/lib/prisma";
 import StoreList from "@/components/store/StoreList";
 
@@ -13,10 +12,5 @@ export default async function UserHomePage() {
     },
   });
 
-  return (
-    <div className="mx-auto w-[90%]">
-      <Header />
-      <StoreList initialStores={initialStores} />
-    </div>
-  );
+  return <StoreList initialStores={initialStores} />;
 }

--- a/src/app/(user)/store/[storeId]/order/page.tsx
+++ b/src/app/(user)/store/[storeId]/order/page.tsx
@@ -1,3 +1,0 @@
-export default function UserOrderPage() {
-  return <h1>사용자가 보는 주문 페이지입니다.</h1>;
-}

--- a/src/app/(user)/store/[storeId]/page.tsx
+++ b/src/app/(user)/store/[storeId]/page.tsx
@@ -1,6 +1,5 @@
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
-import { Header } from "@/components/layout/Header";
 import StoreImage from "@/components/store/StoreImage";
 import StoreInfo from "@/components/store/StoreInfo";
 import StoreDescription from "@/components/store/StoreDescription";
@@ -28,17 +27,14 @@ export default async function StoreDetailPage({ params }: Props) {
   if (!store) notFound();
 
   return (
-    <div className="mx-auto w-[90%]">
-      <Header />
-      <div className="mt-10.5 flex max-w-[1920px] flex-col gap-10.5 md:flex-row">
-        <StoreImage imageUrl={store.imageUrl} />
-        <div className="flex flex-1 flex-col justify-between">
-          <div className="flex flex-col gap-5">
-            <StoreInfo name={store.name} openDays={store.openDays} address={store.address} />
-          </div>
-          <StoreDescription content={store.content} />
-          <StoreActionButtons storeId={storeId} />
+    <div className="mt-10.5 flex max-w-[1920px] flex-col gap-10.5 md:flex-row">
+      <StoreImage imageUrl={store.imageUrl} />
+      <div className="flex flex-1 flex-col justify-between">
+        <div className="flex flex-col gap-5">
+          <StoreInfo name={store.name} openDays={store.openDays} address={store.address} />
         </div>
+        <StoreDescription content={store.content} />
+        <StoreActionButtons storeId={storeId} />
       </div>
     </div>
   );

--- a/src/app/(user)/store/[storeId]/product/[productId]/page.tsx
+++ b/src/app/(user)/store/[storeId]/product/[productId]/page.tsx
@@ -1,0 +1,33 @@
+import ProductImageList from "@/components/product/image/ProductImageList";
+import ProductInfo from "@/components/product/Product-Info";
+import { getProduct } from "@/lib/actions/product";
+import { getStore } from "@/lib/actions/store";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+type Props = {
+  storeId: string;
+  productId: string;
+};
+
+export default async function UserProductDetailPage({ params }: { params: Promise<Props> }) {
+  const storeId = parseInt((await params).storeId);
+  const productId = parseInt((await params).productId);
+
+  if (isNaN(storeId) || isNaN(productId)) {
+    return notFound();
+  }
+
+  const product = await getProduct(productId);
+  const store = await getStore(storeId);
+
+  return (
+    <div className="flex w-[90%] flex-col pb-[40px]">
+      <Link href={`/store/${product.storeId}`} className="f28 w-fit py-[42px]">{`< ${store.name}`}</Link>
+      <div className="product-form flex justify-center">
+        <ProductImageList images={product.images}></ProductImageList>
+        <ProductInfo product={product} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(user)/store/[storeId]/product/[productId]/page.tsx
+++ b/src/app/(user)/store/[storeId]/product/[productId]/page.tsx
@@ -25,7 +25,7 @@ export default async function UserProductDetailPage({ params }: { params: Promis
     <div className="flex w-[90%] flex-col pb-[40px]">
       <Link href={`/store/${product.storeId}`} className="f28 w-fit py-[42px]">{`< ${store.name}`}</Link>
       <div className="product-form flex justify-center">
-        <ProductImageList images={product.images}></ProductImageList>
+        <ProductImageList productName={product.name} images={product.images}></ProductImageList>
         <ProductInfo product={product} />
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,18 +9,84 @@
 @layer components {
 
   /* Font sizes*/
-  .f48 { font-size: 3rem; line-height: 1.4; }       /* 48px */
-  .f40 { font-size: 2.5rem; line-height: 1.4; }     /* 40px */
-  .f36 { font-size: 2.25rem; line-height: 1.4; }     /* 36px */
-  .f28 { font-size: 1.75rem; line-height: 1.4; }     /* 28px */
-  .f24 { font-size: 1.5rem; line-height: 1.5; }      /* 24px */
-  .f22 { font-size: 1.375rem; line-height: 1.5; }    /* 22px */
-  .f20 { font-size: 1.25rem; line-height: 1.5; }     /* 20px */
-  .f18 { font-size: 1.125rem; line-height: 1.5; }    /* 18px */
-  .f16 { font-size: 1rem; line-height: 1.5; }        /* 16px */
-  .f14 { font-size: 0.875rem; line-height: 1.5; }    /* 14px */
-  .f12 { font-size: 0.75rem; line-height: 1.5; }     /* 12px */
-  .f10 { font-size: 0.625rem; line-height: 1.5; }    /* 10px */
+  .f48 {
+    font-size: 3rem;
+    line-height: 1.4;
+  }
+
+  /* 48px */
+  .f40 {
+    font-size: 2.5rem;
+    line-height: 1.4;
+  }
+
+  /* 40px */
+  .f36 {
+    font-size: 2.25rem;
+    line-height: 1.4;
+  }
+
+  /* 36px */
+  .f32 {
+    font-size: 2rem;
+    line-height: 1.4;
+  }
+
+  /* 32px */
+  .f28 {
+    font-size: 1.75rem;
+    line-height: 1.4;
+  }
+
+  /* 28px */
+  .f24 {
+    font-size: 1.5rem;
+    line-height: 1.5;
+  }
+
+  /* 24px */
+  .f22 {
+    font-size: 1.375rem;
+    line-height: 1.5;
+  }
+
+  /* 22px */
+  .f20 {
+    font-size: 1.25rem;
+    line-height: 1.5;
+  }
+
+  /* 20px */
+  .f18 {
+    font-size: 1.125rem;
+    line-height: 1.5;
+  }
+
+  /* 18px */
+  .f16 {
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  /* 16px */
+  .f14 {
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  /* 14px */
+  .f12 {
+    font-size: 0.75rem;
+    line-height: 1.5;
+  }
+
+  /* 12px */
+  .f10 {
+    font-size: 0.625rem;
+    line-height: 1.5;
+  }
+
+  /* 10px */
 
   /* Font weights */
   .text-regular {

--- a/src/components/SquareImage.tsx
+++ b/src/components/SquareImage.tsx
@@ -6,9 +6,10 @@ type Props = {
   alt: string;
   size: number;
   isFixedSize?: boolean;
+  onClick?: () => void;
 };
 
-export default function SquareImage({ src, alt, size, isFixedSize }: Props) {
+export default function SquareImage({ src, alt, size, isFixedSize, onClick }: Props) {
   const imageUrl = typeof src === "string" ? src : useImagePreview(src);
 
   if (!imageUrl) {
@@ -27,7 +28,8 @@ export default function SquareImage({ src, alt, size, isFixedSize }: Props) {
 
   return (
     <div
-      className="relative aspect-square overflow-hidden"
+      onClick={onClick}
+      className={`relative aspect-square overflow-hidden ${onClick ? "cursor-pointer" : ""}`}
       style={{
         maxWidth: `${size}px`,
         maxHeight: `${size}px`,

--- a/src/components/product/Option-Info.tsx
+++ b/src/components/product/Option-Info.tsx
@@ -1,0 +1,28 @@
+import { OptionCategory } from "@/types/product";
+import { Table, TableBody } from "../ui/table";
+import OptionItemInfo from "./Option-Item-Info";
+
+type Props = {
+  option: OptionCategory;
+};
+
+export default function OptionInfo({ option }: Props) {
+  return (
+    <div>
+      <div className="flex flex-row items-center gap-4">
+        <p className="f20 text-sub-text">{option.name}</p>
+        {option.required ? <div className="text-primary-300 f16">필수 선택</div> : null}
+        {option.multiple ? <div className="text-primary-300 f16">복수 선택 가능</div> : null}
+      </div>
+      <div className="mt-2 w-full overflow-hidden rounded-md">
+        <Table className="w-full table-auto">
+          <TableBody>
+            {option.items.map((item) => (
+              <OptionItemInfo key={item.id} item={item} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/product/Option-Item-Info.tsx
+++ b/src/components/product/Option-Item-Info.tsx
@@ -1,0 +1,15 @@
+import { OptionItem } from "@/types/product";
+import { TableCell, TableRow } from "../ui/table";
+
+type Props = {
+  item: OptionItem;
+};
+
+export default function OptionItemInfo({ item }: Props) {
+  return (
+    <TableRow className="border-primary-100 hover:bg-primary-100 border">
+      <TableCell className="min-w-14 font-medium">{item.name}</TableCell>
+      <TableCell className="text-sub-text w-full break-words whitespace-normal">{item.description}</TableCell>
+    </TableRow>
+  );
+}

--- a/src/components/product/Product-Info.tsx
+++ b/src/components/product/Product-Info.tsx
@@ -1,0 +1,21 @@
+import { Product } from "@/types/product";
+import OptionInfo from "./Option-Info";
+import { Button } from "../ui/button";
+
+type Props = {
+  product: Product;
+};
+
+export default function ProductInfo({ product }: Props) {
+  return (
+    <div className="mix-w-[300px] flex w-full max-w-[550px] flex-col gap-5">
+      <p className="f40">{product.name}</p>
+      <p className="f18 text-sub-text">{product.description}</p>
+      <p className="f32 text-primary-300">{product.price.toLocaleString()}원</p>
+      {product.options.map((option) => (
+        <OptionInfo key={option.id} option={option} />
+      ))}
+      <Button className="f16 bg-primary-300 hover:bg-primary-400 h-12 w-full">{"주문하기 >"}</Button>
+    </div>
+  );
+}

--- a/src/components/product/image/Image-Action-Button.tsx
+++ b/src/components/product/image/Image-Action-Button.tsx
@@ -1,0 +1,29 @@
+import { PropsWithChildren } from "react";
+
+type Props = {
+  size: number;
+  onAction: () => void;
+};
+
+export default function ImageActionButton({ size, onAction, children }: PropsWithChildren<Props>) {
+  const xSize = size > 200 ? 40 : 20;
+  const xPadding = size > 200 ? 8 : 4;
+  const xMargin = size > 200 ? 10 : 4;
+
+  return (
+    <button
+      className="absolute z-10 cursor-pointer rounded-full bg-black/20"
+      style={{
+        padding: `${xPadding}px`,
+        top: `${xMargin}px`,
+        right: `${xMargin}px`,
+        width: `${xSize}px`,
+        height: `${xSize}px`,
+      }}
+      type="button"
+      onClick={onAction}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/product/image/ProductImageList.tsx
+++ b/src/components/product/image/ProductImageList.tsx
@@ -3,12 +3,34 @@
 import SquareImage from "@/components/SquareImage";
 import { ProductImage } from "@/types/product";
 import { useState } from "react";
+import ImageActionButton from "./Image-Action-Button";
+import { Download } from "lucide-react";
+import toast from "react-hot-toast";
 
 type Props = {
+  productName: string;
   images: ProductImage[];
 };
 
-export default function ProductImageList({ images }: Props) {
+const downloadImage = async (imageUrl: string, fileName = "downloaded.jpg") => {
+  try {
+    const response = await fetch(imageUrl, { mode: "cors" });
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  } catch {
+    toast.error("이미지 다운로드에 실패했어요");
+  }
+};
+
+export default function ProductImageList({ productName, images }: Props) {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const maxSize = 550;
@@ -17,11 +39,18 @@ export default function ProductImageList({ images }: Props) {
     setCurrentIndex(index);
   };
 
+  const downloadCurrentImage = () => {
+    downloadImage(images[currentIndex].image as string, `${productName}${currentIndex + 1}`);
+  };
+
   return (
     <div className="w-full" style={{ maxWidth: `${maxSize}px` }}>
       <div>
         <div className="relative mb-[10px] aspect-square h-full max-h-[550px] w-full max-w-[550px] overflow-hidden" style={{ maxHeight: `${maxSize}px`, maxWidth: `${maxSize}px` }}>
           <SquareImage key={images[currentIndex].id} src={images[currentIndex].image} alt={"thumbnail"} size={550} />
+          <ImageActionButton size={550} onAction={downloadCurrentImage}>
+            <Download className="h-full w-full text-white" />
+          </ImageActionButton>
         </div>
         <div className="flex flex-wrap gap-[10px]">
           {images

--- a/src/components/product/image/ProductImageList.tsx
+++ b/src/components/product/image/ProductImageList.tsx
@@ -2,24 +2,33 @@
 
 import SquareImage from "@/components/SquareImage";
 import { ProductImage } from "@/types/product";
+import { useState } from "react";
 
 type Props = {
   images: ProductImage[];
 };
 
 export default function ProductImageList({ images }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
   const maxSize = 550;
+
+  const handleImageClick = (index: number) => {
+    setCurrentIndex(index);
+  };
 
   return (
     <div className="w-full" style={{ maxWidth: `${maxSize}px` }}>
       <div>
         <div className="relative mb-[10px] aspect-square h-full max-h-[550px] w-full max-w-[550px] overflow-hidden" style={{ maxHeight: `${maxSize}px`, maxWidth: `${maxSize}px` }}>
-          <SquareImage key={images[0].id} src={images[0].image} alt={"thumbnail"} size={550} />
+          <SquareImage key={images[currentIndex].id} src={images[currentIndex].image} alt={"thumbnail"} size={550} />
         </div>
         <div className="flex flex-wrap gap-[10px]">
-          {images.slice(1).map((src, index) => (
-            <SquareImage key={src.id} src={src.image} alt={`image ${index + 1}`} size={100} isFixedSize={false} />
-          ))}
+          {images
+            .filter((_, i) => i !== currentIndex)
+            .map((src, index) => (
+              <SquareImage key={src.id} src={src.image} alt={`image ${index + 1}`} size={100} isFixedSize={false} onClick={() => handleImageClick(index)} />
+            ))}
         </div>
       </div>
     </div>

--- a/src/components/product/image/ProductImageList.tsx
+++ b/src/components/product/image/ProductImageList.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import SquareImage from "@/components/SquareImage";
+import { ProductImage } from "@/types/product";
+
+type Props = {
+  images: ProductImage[];
+};
+
+export default function ProductImageList({ images }: Props) {
+  const maxSize = 550;
+
+  return (
+    <div className="w-full" style={{ maxWidth: `${maxSize}px` }}>
+      <div>
+        <div className="relative mb-[10px] aspect-square h-full max-h-[550px] w-full max-w-[550px] overflow-hidden" style={{ maxHeight: `${maxSize}px`, maxWidth: `${maxSize}px` }}>
+          <SquareImage key={images[0].id} src={images[0].image} alt={"thumbnail"} size={550} />
+        </div>
+        <div className="flex flex-wrap gap-[10px]">
+          {images.slice(1).map((src, index) => (
+            <SquareImage key={src.id} src={src.image} alt={`image ${index + 1}`} size={100} isFixedSize={false} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/product/image/SelectedImage.tsx
+++ b/src/components/product/image/SelectedImage.tsx
@@ -1,5 +1,6 @@
 import SquareImage from "@/components/SquareImage";
 import { X } from "lucide-react";
+import ImageActionButton from "./Image-Action-Button";
 
 type Props = {
   src: string | File;
@@ -11,10 +12,6 @@ type Props = {
 };
 
 export default function SelectedImage({ src, alt, size, isFixedSize, idx, onRemove }: Props) {
-  const xSize = size > 200 ? 40 : 20;
-  const xPadding = size > 200 ? 8 : 4;
-  const xMargin = size > 200 ? 10 : 4;
-
   return (
     <div
       className="relative"
@@ -26,20 +23,9 @@ export default function SelectedImage({ src, alt, size, isFixedSize, idx, onRemo
       }}
     >
       <SquareImage src={src} alt={alt} size={size} isFixedSize={isFixedSize} />
-      <button
-        className="absolute z-10 cursor-pointer rounded-full bg-black/20"
-        style={{
-          padding: `${xPadding}px`,
-          top: `${xMargin}px`,
-          right: `${xMargin}px`,
-          width: `${xSize}px`,
-          height: `${xSize}px`,
-        }}
-        type="button"
-        onClick={() => onRemove(idx)}
-      >
+      <ImageActionButton size={size} onAction={() => onRemove(idx)}>
         <X className="h-full w-full text-white" />
-      </button>
+      </ImageActionButton>
     </div>
   );
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table data-slot="table" className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return <thead data-slot="table-header" className={cn("[&_tr]:border-b", className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return <tbody data-slot="table-body" className={cn("[&_tr:last-child]:border-0", className)} {...props} />;
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return <tfoot data-slot="table-footer" className={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)} {...props} />;
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return <tr data-slot="table-row" className={cn("hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors", className)} {...props} />;
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn("text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]", className)}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return <td data-slot="table-cell" className={cn("p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]", className)} {...props} />;
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
+  return <caption data-slot="table-caption" className={cn("text-muted-foreground mt-4 text-sm", className)} {...props} />;
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/src/contexts/ProductContext.tsx
+++ b/src/contexts/ProductContext.tsx
@@ -38,7 +38,7 @@ function reducer(state: State, action: Action): State {
     case "ADD_IMAGES":
       return {
         ...state,
-        images: [...state.images, ...action.images.map((file) => ({ id: Date.now(), productId: state.id, image: file }))],
+        images: [...state.images, ...action.images.map((file, index) => ({ id: Date.now() + index, productId: state.id, image: file }))],
       };
 
     case "REMOVE_IMAGE": {

--- a/src/lib/actions/store.ts
+++ b/src/lib/actions/store.ts
@@ -1,0 +1,16 @@
+import { prisma } from "@/lib/prisma";
+import { StoreDetail } from "@/types/store";
+
+export const getStore = async (storeId: number): Promise<StoreDetail> => {
+  const storeData = await prisma.store.findUnique({
+    where: { id: storeId },
+  });
+
+  if (!storeData) {
+    throw Error("조회된 가게가 없습니다.");
+  }
+
+  return {
+    ...storeData,
+  };
+};


### PR DESCRIPTION
## ✅ PR 내용 요약
- 상품 상세 화면을 구현했습니다. 상품 정보를 조회 후 표시하고 다운로드 버튼을 통해 이미지를 다운로드 할 수 있습니다.

## 🔧 작업 내역
- [x] 상품 상세 화면 UI 구현
- [x] 상품 이미지 다운로드 구현
- [x] 이미지 클릭 시 썸네일과 위치 변경되게 구현

## 📎 관련 이슈
- 관련 이슈 번호: #23 

## 📸 스크린샷 (UI 변경 시 필수)
<table>
  <tr>
    <td align="center">페이지명</td>
    <td align="center">이미지</td>
  </tr>
  <tr>
    <td>상품 상세 페이지</td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/2afc0661-425c-44b9-8b06-8ada56659e5a" width="1413" />
    </td>
  </tr>
</table>

## 💬 기타 사항
- 코드 리뷰어에게 공유하고 싶은 정보가 있다면 적어주세요.
