### PR TITLE
[#27] feat: 상품 목록 페이지 구현 및 가게별 상품 조회 API 연동

### DIFF
--- a/src/app/(user)/store/[storeId]/order/page.tsx
+++ b/src/app/(user)/store/[storeId]/order/page.tsx
@@ -1,3 +1,27 @@
-export default function UserOrderPage() {
-  return <h1>사용자가 보는 주문 페이지입니다.</h1>;
+import { getProductsByStore } from "@/lib/api/products";
+import { Header } from "@/components/layout/Header";
+import ProductListPage from "@/components/product/ProductList";
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+
+export default async function UserOrderPage({ params }: { params: { storeId: string } }) {
+  const storeId = parseInt(params.storeId, 10);
+  if (isNaN(storeId)) notFound();
+
+  const [store, products] = await Promise.all([
+    prisma.store.findUnique({
+      where: { id: storeId },
+      select: { name: true },
+    }),
+    getProductsByStore(params.storeId),
+  ]);
+
+  if (!store) notFound();
+
+  return (
+    <div className="mx-auto w-[90%]">
+      <Header />
+      <ProductListPage storeName={store.name} products={products} />
+    </div>
+  );
 }

--- a/src/components/common/ItemCard.tsx
+++ b/src/components/common/ItemCard.tsx
@@ -14,7 +14,7 @@ export function ItemCard({ id, title, imageUrl, href, footerText = "See More >",
 
         <div className={`${bgColorClass} flex h-[7rem] flex-col justify-between p-4`}>
           <h3 className="f20 text-medium text-primary-text">{title}</h3>
-          <p className="f10 mt-2 text-black">{footerText}</p>
+          <p className="f10 mt-2 text-black hover:underline">{footerText}</p>
         </div>
       </Link>
     </div>

--- a/src/components/common/ItemList.tsx
+++ b/src/components/common/ItemList.tsx
@@ -17,7 +17,7 @@ export default function ItemCardList({ items }: Props) {
           ))}
         </div>
       ) : (
-        <p className="text-sub-text mt-10.5 text-center">조회된 항목이 없습니다.</p>
+        <p className="text-sub-text mt-10.5 text-center">등록된 항목이 없습니다.</p>
       )}
     </div>
   );

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import ItemCardList from "@/components/common/ItemList";
+import type { ProductPreview } from "@/types/product";
+
+type Props = {
+  storeName: string;
+  products: ProductPreview[];
+};
+
+export default function ProductListPage({ storeName, products }: Props) {
+  const router = useRouter();
+
+  const cards = products.map((product) => ({
+    id: product.id,
+    title: product.name,
+    imageUrl: product.imageUrl ?? "/images/cake_image.png",
+    href: `/product/${product.id}`,
+    footerText: "주문하기 >",
+    bgColorClass: "bg-secondary-100",
+  }));
+
+  return (
+    <div className="mx-auto mt-10.5 w-full">
+      <div className="mx-10.5 flex items-center gap-2">
+        <button onClick={() => router.back()} className="f28 text-medium text-primary-text hover:text-sub-text ml-10.5 leading-none">
+          &lt; {storeName}
+        </button>
+      </div>
+      <ItemCardList items={cards} />
+    </div>
+  );
+}

--- a/src/components/store/StoreList.tsx
+++ b/src/components/store/StoreList.tsx
@@ -38,14 +38,15 @@ export default function StoreList({ initialStores }: Props) {
   }));
 
   return (
-    <div className="mx-auto mt-10.5 w-[80%]">
-      <RegionSelectBox
-        onChange={(province, district) => {
-          setSelectedProvince(province);
-          setSelectedDistrict(district);
-        }}
-      />
-
+    <div className="mx-auto mt-10.5 w-full">
+      <div className="ml-15.5">
+        <RegionSelectBox
+          onChange={(province, district) => {
+            setSelectedProvince(province);
+            setSelectedDistrict(district);
+          }}
+        />
+      </div>
       <ItemCardList items={cards} />
     </div>
   );

--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -1,0 +1,10 @@
+import { ProductPreview } from "@/types/product";
+
+export async function getProductsByStore(storeId: string): Promise<ProductPreview[]> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/stores/${storeId}/products`, {
+    next: { revalidate: 60 },
+  });
+
+  if (!res.ok) return [];
+  return res.json();
+}


### PR DESCRIPTION
## ✅ PR 내용 요약
- 가게 상세 페이지에서 해당 가게의 상품 목록을 조회하고 카드 형태로 출력하는 상품 목록 페이지를 구현했습니다.
- 서버 컴포넌트에서 storeId를 기반으로 가게 이름과 상품 데이터를 병렬로 fetch하여 ProductListPage에 전달합니다.
- 상품 목록은 공통 컴포넌트인 ItemCardList를 활용해 일관된 UI로 구성됩니다.

## 🔧 작업 내역
- [X] getProductsByStore(storeId) 유틸 함수 추가
- [X] ProductListPage 클라이언트 컴포넌트 구현
- [X] storeId 기반 가게 이름 및 상품 목록 병렬 조회
- [X] 상품 카드를 ItemCardList를 통해 출력
- [X] 상단에 가게 이름과 뒤로가기 버튼 UI 추가

## 📎 관련 이슈
- 관련 이슈 번호: #27 
- resolves #27 

## 📸 스크린샷 (UI 변경 시 필수)
<img width="1512" alt="스크린샷 2025-05-23 오후 5 12 05" src="https://github.com/user-attachments/assets/99194965-0e8a-4754-8ad9-7e6ac704724c" />