### PR TITLE
[#38] refactor: 상단 타이틀 및 뒤로가기 버튼 컴포넌트화

### DIFF
--- a/src/app/(user)/store/[storeId]/product/[productId]/page.tsx
+++ b/src/app/(user)/store/[storeId]/product/[productId]/page.tsx
@@ -2,8 +2,8 @@ import ProductImageList from "@/components/product/image/ProductImageList";
 import ProductInfo from "@/components/product/Product-Info";
 import { getProduct } from "@/lib/actions/product";
 import { getStore } from "@/lib/actions/store";
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import BackTitle from "@/components/common/BackTitle";
 
 type Props = {
   storeId: string;
@@ -22,9 +22,9 @@ export default async function UserProductDetailPage({ params }: { params: Promis
   const store = await getStore(storeId);
 
   return (
-    <div className="flex w-[90%] flex-col pb-[40px]">
-      <Link href={`/store/${product.storeId}`} className="f28 w-fit py-[42px]">{`< ${store.name}`}</Link>
-      <div className="product-form flex justify-center">
+    <div className="mt-10.5 flex w-full flex-col">
+      <BackTitle title={store.name} />
+      <div className="product-form mt-10.5 flex justify-center">
         <ProductImageList productName={product.name} images={product.images}></ProductImageList>
         <ProductInfo product={product} />
       </div>

--- a/src/components/common/BackTitle.tsx
+++ b/src/components/common/BackTitle.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+type BackTitleProps = {
+  title: string;
+};
+
+export default function BackTitle({ title }: BackTitleProps) {
+  const router = useRouter();
+
+  return (
+    <div className="ml-15 flex items-center gap-2">
+      <button onClick={() => router.back()} className="f28 text-primary-text hover:text-sub-text leading-none font-medium">
+        &lt; {title}
+      </button>
+    </div>
+  );
+}

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import ItemCardList from "@/components/common/ItemList";
 import type { ProductPreview } from "@/types/product";
+import BackTitle from "@/components/common/BackTitle";
 
 type Props = {
   storeId: number;
@@ -11,8 +11,6 @@ type Props = {
 };
 
 export default function ProductListPage({ storeId, storeName, products }: Props) {
-  const router = useRouter();
-
   const cards = products.map((product) => ({
     id: product.id,
     title: product.name,
@@ -24,11 +22,7 @@ export default function ProductListPage({ storeId, storeName, products }: Props)
 
   return (
     <div className="mx-auto mt-10.5 w-full">
-      <div className="mx-10.5 flex items-center gap-2">
-        <button onClick={() => router.back()} className="f28 text-medium text-primary-text hover:text-sub-text ml-10.5 leading-none">
-          &lt; {storeName}
-        </button>
-      </div>
+      <BackTitle title={storeName} />
       <ItemCardList items={cards} />
     </div>
   );


### PR DESCRIPTION
## ✅ PR 내용 요약
- BackTitle 공통 컴포넌트를 생성하고 상품 목록/상세 페이지에 적용했습니다.

## 🔧 작업 내역
- [X] 뒤로가기 버튼 + 타이틀 조합을 위한 BackTitle 컴포넌트 구현
- [X] ProductListPage 및 UserProductDetailPage에 BackTitle 컴포넌트 적용

## 📎 관련 이슈
- 관련 이슈 번호: #38 
- resolves #38 

## 📸 스크린샷 (UI 변경 시 필수)
- 변경된 UI가 있다면 스크린샷을 첨부해주세요.
<img width="500" alt="스크린샷 2025-05-23 오후 10 08 15" src="https://github.com/user-attachments/assets/682a77b3-a8fd-4882-a613-1dcf8dcb8d43" />

<img width="500" alt="스크린샷 2025-05-23 오후 10 08 28" src="https://github.com/user-attachments/assets/82e0c3eb-492c-47af-a36b-e8da0c1c8659" />
