### PR TITLE
[#39] feat: 사장님 마이페이지 구현

### DIFF
--- a/src/app/owner/page.tsx
+++ b/src/app/owner/page.tsx
@@ -1,3 +1,28 @@
-export default function MyPage() {
-  return <div>사장님 마이 페이지입니다.</div>;
+import { getProductsByStore } from "@/lib/api/products";
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import OwnerProductList from "@/components/product/OwnerProductList";
+import { verifySession } from "@/lib/actions/sessions";
+
+export default async function OwnerMyPage() {
+  const session = await verifySession();
+  if (!session) notFound();
+
+  const memberId = +session.id;
+  if (isNaN(memberId)) notFound();
+
+  const store = await prisma.store.findUnique({
+    where: { memberId: memberId },
+    select: { id: true, name: true },
+  });
+
+  if (!store) notFound();
+
+  const products = await getProductsByStore(store.id.toString());
+
+  return (
+    <div className="mx-auto w-full">
+      <OwnerProductList products={products} />
+    </div>
+  );
 }

--- a/src/components/product/Option-Info.tsx
+++ b/src/components/product/Option-Info.tsx
@@ -14,7 +14,7 @@ export default function OptionInfo({ option }: Props) {
         {option.required ? <div className="text-primary-300 f16">필수 선택</div> : null}
         {option.multiple ? <div className="text-primary-300 f16">복수 선택 가능</div> : null}
       </div>
-      <div className="mt-2 w-full overflow-hidden rounded-md">
+      <div className="border-primary-100 mt-2 w-full overflow-hidden rounded-md border">
         <Table className="w-full table-auto">
           <TableBody>
             {option.items.map((item) => (

--- a/src/components/product/Option-Item-Info.tsx
+++ b/src/components/product/Option-Item-Info.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function OptionItemInfo({ item }: Props) {
   return (
-    <TableRow className="border-primary-100 hover:bg-primary-100 border">
+    <TableRow className="border-primary-100 hover:bg-primary-100 border-b">
       <TableCell className="min-w-14 font-medium">{item.name}</TableCell>
       <TableCell className="text-sub-text w-full break-words whitespace-normal">{item.description}</TableCell>
     </TableRow>

--- a/src/components/product/OwnerProductList.tsx
+++ b/src/components/product/OwnerProductList.tsx
@@ -1,0 +1,32 @@
+import ItemCardList from "@/components/common/ItemList";
+import type { ProductPreview } from "@/types/product";
+import { Button } from "../ui/button";
+import Link from "next/link";
+
+type Props = {
+  products: ProductPreview[];
+};
+
+export default function OwnerProductList({ products }: Props) {
+  const cards = products.map((product) => ({
+    id: product.id,
+    title: product.name,
+    imageUrl: product.imageUrl ?? "/images/cake_image.png",
+    href: `/owner/product/${product.id}/edit`,
+    footerText: "수정하기 >",
+    bgColorClass: "bg-secondary-100",
+  }));
+
+  return (
+    <div className="mx-auto mt-10.5 w-full">
+      <div className="mx-10.5 flex items-center justify-end gap-2">
+        <Link href="owner/product/new">
+          <Button className="bg-primary-300 hover:bg-primary-400 h-12 w-40 rounded-none">
+            <div className="f22 font-semibold">상품 추가</div>
+          </Button>
+        </Link>
+      </div>
+      <ItemCardList items={cards} />
+    </div>
+  );
+}

--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -2,7 +2,7 @@ import { ProductPreview } from "@/types/product";
 
 export async function getProductsByStore(storeId: string): Promise<ProductPreview[]> {
   const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/stores/${storeId}/products`, {
-    next: { revalidate: 60 },
+    cache: "no-store",
   });
 
   if (!res.ok) return [];


### PR DESCRIPTION
## ✅ PR 내용 요약
- 사장님 마이페이지 화면에 상품 목록과 상품 추가 버튼을 구현했습니다.

## 🔧 작업 내역
- [x] 사장님 마이페이지 상품 목록 구현 
- [x] 상품 추가 버튼 구현
- [x] 상품 목록 조회 no-store 설정

## 📎 관련 이슈
- 관련 이슈 번호: #39 

## 📸 스크린샷 (UI 변경 시 필수)
<table>
  <tr>
    <td align="center">페이지명</td>
    <td align="center">이미지</td>
  </tr>
  <tr>
    <td>사장님 마이 페이지</td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/7d0e9e53-0b35-4c45-8039-23a34e8e4b3b" width="1413" />
    </td>
  </tr>
</table>

## 💬 기타 사항
- 코드 리뷰어에게 공유하고 싶은 정보가 있다면 적어주세요.
