### PR TITLE
[#47] refactor: 상품 입력 폼에서 설명 입력 컴포넌트 Input에서 Textarea로 변경

### DIFF
--- a/src/components/product/Product-Info-Input-Form.tsx
+++ b/src/components/product/Product-Info-Input-Form.tsx
@@ -9,6 +9,7 @@ import OptionInputForm from "./Option-Input-Form";
 import { Button } from "../ui/button";
 import { useProductContext } from "@/contexts/ProductContext";
 import { DialogButton } from "../Dialog-Button";
+import { Textarea } from "../ui/textarea";
 
 type Props = {
   isSubmitting: boolean;
@@ -32,7 +33,7 @@ export default function ProductInfoInputForm({ isSubmitting, onDelete }: Props) 
     dispatch({ type: "UPDATE_FIELD", key: "name", value: event.target.value });
   };
 
-  const handleChangeDesc = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeDesc = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     dispatch({ type: "UPDATE_FIELD", key: "description", value: event.target.value });
   };
 
@@ -56,7 +57,9 @@ export default function ProductInfoInputForm({ isSubmitting, onDelete }: Props) 
   return (
     <div className="mix-w-[300px] flex w-full max-w-[550px] flex-col gap-[20px]">
       <LabelWithInput name="name" label="케이크 이름" type="text" value={state.name} placeholder="케이크 이름을 입력해주세요" onChange={handleChangeName} required={true} />
-      <LabelWithInput name="desc" label="케이크 설명" type="text" value={state.description} placeholder="케이크 설명을 입력해주세요" onChange={handleChangeDesc} />
+      <LabelWithInput name="desc" label="케이크 설명" type="text">
+        <Textarea className="h-36" id="desc" name="desc" placeholder="케이크 설명을 입력해주세요" rows={6} maxLength={1000} value={state.description} onChange={handleChangeDesc} />
+      </LabelWithInput>
       <LabelWithInput name="price" label="케이크 가격">
         <Input id="price" name="price" type="text" inputMode="numeric" value={price} maxLength={11} placeholder="케이크 가격을 입력해주세요" onChange={handleChangePrice} required={true} />
       </LabelWithInput>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };


### PR DESCRIPTION
## ✅ PR 내용 요약
- 상품 입력 폼에서 설명 입력 컴포넌트를 변경했습니다.
- shadcn Textarea 컴포넌트를 추가했습니다.

## 🔧 작업 내역
- [x] shadcn Textarea 컴포넌트 추가
- [x] 상품 입력 폼에서 설명 입력 컴포넌트를 Input에서 Textarea로 변경

## 📎 관련 이슈
- 관련 이슈 번호: #47 

## 📸 스크린샷 (UI 변경 시 필수)
<table>
  <tr>
    <td align="center">페이지명</td>
    <td align="center">이미지</td>
  </tr>
    <tr>
    <td>변경 전</td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/112f8cbd-43f5-4f8f-aa61-bb7c5d722204" width="1422" />
    </td>
  </tr>
  <tr>
    <td>변경 후</td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/5643b4fe-b5ca-4806-871d-a4ed3f57ba97" width="1413" />
    </td>
  </tr>
</table>


## 💬 기타 사항
- 코드 리뷰어에게 공유하고 싶은 정보가 있다면 적어주세요.
