### PR TITLE
[#55] feat: /chat 페이지 기능 개선

### DIFF
--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -1,6 +1,8 @@
 import { Header } from "@/components/layout/Header";
 import { Sidebar } from "@/components/chat/Sidebar";
 
+export const revalidate = 0;
+
 export default function ChatLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="mx-auto flex h-screen w-[90%] flex-col items-center overflow-hidden">

--- a/src/components/chat/CreateOrJoinChatButton.tsx
+++ b/src/components/chat/CreateOrJoinChatButton.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import type { ButtonProps } from "@/components/ui/button";
+import toast from "react-hot-toast";
 
 type Props = {
   storeId: number;
@@ -27,11 +28,11 @@ export default function CreateOrJoinChatButton({ storeId, className, variant, ch
       if (data.ok && data.ok && data.roomId) {
         router.push(`/chat/${data.roomId}`); // 채팅 페이지로 이동
       } else {
-        alert(data.message);
+        toast.error(data.message);
       }
     } catch (error) {
       console.error("채팅방 생성 오류:", error);
-      alert("문제가 발생했습니다. 다시 시도해주세요.");
+      toast.error("문제가 발생했습니다. 다시 시도해주세요.");
     }
   };
 

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useSession } from "@/hooks/session-context";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { LogIn } from "lucide-react";
 import { LogoutButton } from "./LogoutButton";
@@ -10,8 +10,15 @@ import { LogoutButton } from "./LogoutButton";
 export default function Nav() {
   const { session } = useSession();
   const pathname = usePathname();
+  const router = useRouter();
 
   const isActive = (path: string) => pathname === path;
+
+  const handleChatClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    router.push("/chat");
+    router.refresh();
+  };
 
   // href 임시 설정
   return (
@@ -22,7 +29,7 @@ export default function Nav() {
         </Link>
 
         {session && (
-          <Link href="/chat" className={cn("hover:text-primary flex items-center font-medium transition-colors", isActive("/chat") ? "text-primary" : "text-sub-text")}>
+          <Link href="/chat" onClick={handleChatClick} className={cn("hover:text-primary flex items-center font-medium transition-colors", isActive("/chat") ? "text-primary" : "text-sub-text")}>
             CHAT
           </Link>
         )}

--- a/src/data/member.ts
+++ b/src/data/member.ts
@@ -8,6 +8,10 @@ export const getMemberByEmail = async (email: string) => {
 export const getChatRoomsByMember = async () => {
   const session = await verifySession();
 
+  if (!session) {
+    throw new Error("인증된 사용자만 사용할 수 있습니다.");
+  }
+
   const member = await prisma.member.findUnique({
     where: { id: Number(session.id) },
   });

--- a/src/lib/actions/chat.ts
+++ b/src/lib/actions/chat.ts
@@ -41,6 +41,11 @@ export const getChatMessages = async (roomId: number) => {
 
 export const deleteRoom = async (roomId: string) => {
   const session = await verifySession();
+
+  if (!session) {
+    throw new Error("인증된 사용자만 사용할 수 있습니다.");
+  }
+
   const userId = Number(session.id);
 
   const id = Number(roomId);


### PR DESCRIPTION
## ✅ PR 내용 요약
/chat 페이지 기능 개선

## 🔧 작업 내역
- 채팅방 생성 실패시 toast.error() 처리
- ChatLayout revalidate = 0 설정
- Nav 컴포넌트에서 /chat router.refresh() 처리

## 📎 관련 이슈
- 관련 이슈 번호: #55 
