### PR TITLE
[#60] fix: 상품 수정 화면 접근 시 자신의 상품 아닐 경우 접근 불가능하게 처리

### DIFF
--- a/src/app/owner/product/[productId]/edit/page.tsx
+++ b/src/app/owner/product/[productId]/edit/page.tsx
@@ -1,6 +1,8 @@
 import ProductInputForm from "@/components/product/Product-Input-Form";
 import { ProductProvider } from "@/contexts/ProductContext";
 import { getProduct } from "@/lib/actions/product";
+import { getMyStoreId } from "@/lib/actions/store";
+import { redirect } from "next/navigation";
 
 type Props = {
   productId: string;
@@ -9,10 +11,18 @@ type Props = {
 export default async function ProductEditPage({ params }: { params: Promise<Props> }) {
   const productId = parseInt((await params).productId);
   if (isNaN(productId)) {
-    throw Error("유효하지 않은 상품 ID 입니다.");
+    redirect("/owner");
   }
 
   const product = await getProduct(productId);
+  if (!product) {
+    redirect("/owner");
+  }
+
+  const storeId = await getMyStoreId();
+  if (!storeId || storeId !== product.storeId) {
+    redirect("/owner");
+  }
 
   return (
     <div className="flex w-[90%] flex-col pb-[40px]">

--- a/src/lib/actions/store.ts
+++ b/src/lib/actions/store.ts
@@ -1,5 +1,20 @@
 import { prisma } from "@/lib/prisma";
 import { StoreDetail } from "@/types/store";
+import { verifySession } from "./sessions";
+
+export const getMyStoreId = async () => {
+  const session = await verifySession();
+  if (!session) return;
+
+  const storeId = await prisma.store.findUnique({
+    where: { memberId: +session.id },
+    select: {
+      id: true,
+    },
+  });
+
+  return storeId?.id;
+};
 
 export const getStore = async (storeId: number): Promise<StoreDetail> => {
   const storeData = await prisma.store.findUnique({


### PR DESCRIPTION
## ✅ PR 내용 요약
- 상품 수정 화면 접근 시 자신의 상품 아닐 경우 접근 불가능하게 처리

## 🔧 작업 내역
- [x] 상품 수정 화면 접근 시 상품의 storeId와 사용자의 storeId 비교

## 📎 관련 이슈
- 관련 이슈 번호: #60 
